### PR TITLE
Add After Text AppMenu Option

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -118,6 +118,9 @@
         <entry name="appmenuNextToIconAndText" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="appmenuAfterText" type="Bool">
+            <default>false</default>
+        </entry>
     </group>
 
     <group name="MouseControl">

--- a/package/contents/ui/AppMenu.qml
+++ b/package/contents/ui/AppMenu.qml
@@ -6,6 +6,8 @@ import org.kde.plasma.components 2.0 as PlasmaComponents
 Item {
     id: appmenu
     anchors.fill: parent
+    // set the left margin to give space to title text
+    anchors.leftMargin: plasmoid.configuration.appmenuAfterText ? titleTextWidth + 20 : 0
 
     property bool appmenuEnabled: plasmoid.configuration.appmenuEnabled
     property bool appmenuNextToButtons: plasmoid.configuration.appmenuNextToButtons
@@ -19,7 +21,7 @@ Item {
                                                 ? appmenu.childrenRect.width + (appmenuButtonsOffsetEnabled ? controlButtonsArea.width : 0)
                                                 : 0
 
-    visible: appmenuEnabledAndNonEmpty && (appmenuNextToIconAndText || mouseHover || appmenuOpened)
+    visible: appmenuEnabledAndNonEmpty && (appmenuNextToIconAndText || mouseHover || appmenuOpened) && !noWindowVisible // this added from other user named kupiqu
 
     GridLayout {
         id: buttonGrid

--- a/package/contents/ui/config/ConfigAppMenu.qml
+++ b/package/contents/ui/config/ConfigAppMenu.qml
@@ -9,6 +9,7 @@ Item {
     property alias cfg_appmenuNextToButtons: appmenuNextToButtons.checked
     property alias cfg_appmenuFillHeight: appmenuFillHeight.checked
     property alias cfg_appmenuNextToIconAndText: appmenuNextToIconAndText.checked
+    property alias cfg_appmenuAfterText: appmenuAfterText.checked
 
     GroupBox {
         id: appmenuEnabled
@@ -40,6 +41,12 @@ Item {
             CheckBox {
                 id: appmenuNextToIconAndText
                 text: i18n("Show next to icon and text")
+                Layout.columnSpan: 2
+            }
+            
+            CheckBox {
+                id: appmenuAfterText
+                text: i18n("Show after text")
                 Layout.columnSpan: 2
             }
         }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -84,6 +84,8 @@ Item {
     property bool mouseHover: false
     property bool isActiveWindowPinned: false
     property bool isActiveWindowMaximized: false
+    
+    property int titleTextWidth: 0
 
     property bool appmenuNextToIconAndText: plasmoid.configuration.appmenuNextToIconAndText
 
@@ -171,7 +173,7 @@ Item {
             toggleMinimized()
         }
     }
-
+    
     PlasmaComponents.Label {
         id: noWindowText
         property double noWindowTextMargin: (parent.height - implicitHeight) / 2
@@ -198,7 +200,8 @@ Item {
         anchors.top: parent.top
         anchors.bottom: parent.bottom
 
-        property double appmenuOffsetLeft: (bp === 0 || bp === 2) ? appmenu.appmenuOffsetWidth : 0
+        // check for new option AfterText before give the appmenu offset
+        property double appmenuOffsetLeft: (bp === 0 || bp === 2) && !plasmoid.configuration.appmenuAfterText ? appmenu.appmenuOffsetWidth : 0
         property double appmenuOffsetRight: (bp === 1 || bp === 3) ? appmenu.appmenuOffsetWidth : 0
 
         anchors.left: parent.left
@@ -245,7 +248,14 @@ Item {
                 source: model.decoration
                 visible: plasmoid.configuration.showWindowIcon
             }
-
+            
+            // I use this dummy text to calculate the width of title
+            Text {
+                id: testText
+                text: textType === 1 ? model.AppName : replaceTitle(model.display)
+                visible: false
+            }
+            
             // window title
             PlasmaComponents.Label {
                 id: windowTitleText
@@ -263,7 +273,7 @@ Item {
                 verticalAlignment: Text.AlignVCenter
                 text: textType === 1 ? model.AppName : replaceTitle(model.display)
                 wrapMode: Text.Wrap
-                width: properWidth
+                width: plasmoid.configuration.appmenuAfterText ? (testText.width > 1000 ? 1000 : testText.width) : properWidth // I check here and set the width for my monitor 1000 is perfect as limit but I didnt have time to make in config var to get input from user
                 elide: noElide ? Text.ElideNone : Text.ElideRight
                 visible: plasmoid.configuration.showWindowTitle
                 font.pixelSize: fontPixelSize
@@ -287,6 +297,11 @@ Item {
                         font.pixelSize = newPixelSize < minimumPixelSize ? minimumPixelSize : newPixelSize
                     }
                     allowFontSizeChange--
+                }
+                
+                // I update the titleTextWidth to pass it in appmenu (Maybe is bad but i dont know about qml... sorry)
+                Component.onCompleted: {
+                    titleTextWidth = windowTitleText.width
                 }
             }
 
@@ -380,7 +395,7 @@ Item {
                 }
             }
         }
-
+        
         AppMenu {
             id: appmenu
         }


### PR DESCRIPTION
I added new option.. After icon and title text I put the appMenu. I'm not good in QML, in fact, I just learn it! Forgive me for my mistackes!

![newmenuoption](https://cloud.githubusercontent.com/assets/5513284/23462531/e05b41a0-fe96-11e6-8d48-eaefcf1316a8.png)